### PR TITLE
Fix the fix/59 decoration regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kleiderordnung-berlin",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kleiderordnung-berlin",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kleiderordnung-berlin",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kleiderordnung-berlin",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleiderordnung-berlin",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "portfolio website for sustainable stylist Tina Steinke",
   "scripts": {
     "install": "node install-local-environment.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleiderordnung-berlin",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "portfolio website for sustainable stylist Tina Steinke",
   "scripts": {
     "install": "node install-local-environment.js",

--- a/src/css/z_decoration.css
+++ b/src/css/z_decoration.css
@@ -33,6 +33,7 @@ body.page.home main { /* decoration-parallax-group */
 }
 
 /* ensure foreground and following sections stay in front of the decoration layer */
+.offers__offer__image picture img,
 body.archive main > section,
 body.archive main > div,
 body.archive footer,

--- a/src/css/z_decoration.css
+++ b/src/css/z_decoration.css
@@ -162,14 +162,7 @@ body.page.home .decoration__container { /* decoration-parallax-layer-background 
   }
 }
 
-@supports (not (prefers-color-scheme: dark)) {
-  body.archive .decoration__container,
-  body.category .decoration__container,
-  body.search .decoration__container,
-  body.page.home .decoration__container {
-    transform: translateZ(0);
-  }
-}
+/* iPhone <13 CSS workaround obsoleted by more stable JS, setting body.prefers-reduced-motion */
 
 /* stylelint-disable-next-line no-descending-specificity */
 body.prefers-reduced-motion .decoration__container {

--- a/src/functions.php
+++ b/src/functions.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'KLEIDERORDNUNG_THEME_VERSION' ) ) {
-  define( 'KLEIDERORDNUNG_THEME_VERSION', '3.7.0' );
+  define( 'KLEIDERORDNUNG_THEME_VERSION', '3.7.1' );
 }
 
 if ( ! defined( 'KLEIDERORDNUNG_DIR' ) ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'KLEIDERORDNUNG_THEME_VERSION' ) ) {
-  define( 'KLEIDERORDNUNG_THEME_VERSION', '3.6.2' );
+  define( 'KLEIDERORDNUNG_THEME_VERSION', '3.7.0' );
 }
 
 if ( ! defined( 'KLEIDERORDNUNG_DIR' ) ) {

--- a/src/style.css
+++ b/src/style.css
@@ -4,8 +4,8 @@
  Description:  WordPress Classic Theme for Kleiderordnung.Berlin by Ingo Steinke (web development), Ina Nixdorf (web design), Tina Steinke (requirements)
  Author:       openmindculture
  Author URI:   https://www.ingo-steinke.com/
- Version:      3.6.2
- Tested up to: 6.5.5
+ Version:      3.7.0
+ Tested up to: 6.6.1
  License:      proprietary
  Tags:         Tags: wordpress-theme,wordpress-classic-theme,classic-theme,classic,fashion,sustainability,webperf
  Text Domain:  kleiderordnung

--- a/src/style.css
+++ b/src/style.css
@@ -4,7 +4,7 @@
  Description:  WordPress Classic Theme for Kleiderordnung.Berlin by Ingo Steinke (web development), Ina Nixdorf (web design), Tina Steinke (requirements)
  Author:       openmindculture
  Author URI:   https://www.ingo-steinke.com/
- Version:      3.7.0
+ Version:      3.7.1
  Tested up to: 6.6.1
  License:      proprietary
  Tags:         Tags: wordpress-theme,wordpress-classic-theme,classic-theme,classic,fashion,sustainability,webperf


### PR DESCRIPTION
closes #59 

The fixed fix does not break the intended effect in modern browsers starting from Safari 15 on iPhone 11. It still glitches, but much less, in older iPhones that don't apply the correct z-index at the topmost decoration container position. When scrolling down, everything works as expected, i.e. a static decoration without any special scrolling effect.